### PR TITLE
fix(ops): persisted opera-swap script with trace-node safety guard

### DIFF
--- a/scripts/SWAP-RUNBOOK.md
+++ b/scripts/SWAP-RUNBOOK.md
@@ -1,0 +1,191 @@
+# Opera Binary Swap Runbook — Testnet RPC
+
+This runbook covers swapping the `opera` binary on the testnet RPC instance
+(`i-0317eabd98fdf3951`). The same flow applies to mainnet RPC and validator
+hosts with different target paths.
+
+It pairs with `scripts/swap-testnet-opera.sh`, which enforces every check
+below programmatically. Prefer the script. This document exists for when
+you need to reason about what the script is doing or drop back to manual
+steps during an incident.
+
+## Why this runbook exists
+
+On **2026-04-17 ~15:41 UTC** an SSM swap command against
+`i-0317eabd98fdf3951` targeted `/home/ubuntu/VinuChain/build/` instead of
+`/home/ubuntu/vinu-txtrace/build/`. The public trace RPC lost `debug_*` /
+`trace_*` support until the correct checkout was identified and rebuilt.
+
+Root cause: the swap logic lived only in ad-hoc SSM command bodies composed
+in a Claude session. There was no persisted script, no checked-in runbook,
+and no precondition guard against "wrong checkout". This runbook plus
+`swap-testnet-opera.sh` closes that gap.
+
+## Target layout on the testnet RPC instance
+
+| Path                             | Role                                           | Notes                                                                    |
+| -------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------ |
+| `/home/ubuntu/vinu-txtrace/`     | **Trace RPC node** — serves public RPC traffic | `run_node.sh` contains `--tracenode` and `--db.preset pbl-1`. **Always the swap target on this host.** |
+| `/home/ubuntu/VinuChain/`        | Secondary checkout — non-trace                 | Does not serve public traffic. Do not swap here to upgrade the RPC.      |
+
+Verify before doing anything else:
+
+```bash
+grep -l -- --tracenode /home/ubuntu/*/build/run_node.sh
+```
+
+The path that grep prints is the trace node's checkout. That is the value
+you pass as `--target-dir`.
+
+## Pre-flight checklist
+
+Run through this before invoking any swap command.
+
+- [ ] You are logged in (or SSM-exec'd in) as `ubuntu`. Never as `root`.
+- [ ] The instance ID matches the host you intend to operate on. Cross-check via `aws ssm describe-instance-information`.
+- [ ] The new binary was **built on the instance** (never shipped from a
+      workstation — glibc mismatches will silently produce a binary that
+      fails to start or runs against a different libc version). See the
+      "Build on instance" section below.
+- [ ] The new binary's expected version string (e.g. `2.0.5-elemont`) is
+      known up front. `swap-testnet-opera.sh` will refuse to proceed if
+      `opera version` does not match.
+- [ ] The target's `run_node.sh` still contains `--tracenode` (for the
+      trace node) and `--db.preset pbl-1`.
+- [ ] You know the rollback path: the previous binary stays at
+      `build/opera.bak.<version>-<timestamp>` — rollback is
+      `mv build/opera.bak.* build/opera && bash build/run_node.sh`.
+
+If any box is unchecked, stop and fix that first.
+
+## Build on instance
+
+The task agent that kicks off a release prebuilds the new binary on the
+instance. The output path convention is `<target-dir>/build/opera.new`:
+
+```bash
+# On the instance, as ubuntu
+cd /home/ubuntu/vinu-txtrace
+git fetch --tags origin
+git checkout v2.0.5-elemont
+make opera                 # produces build/opera (still the old name)
+mv build/opera build/opera.new
+```
+
+Do NOT overwrite `build/opera` here — the node is still serving traffic
+from that file. The swap script moves the binary into place only after the
+node has stopped cleanly.
+
+## Performing the swap (preferred path)
+
+From an SSM send-command body on the instance:
+
+```bash
+sudo -iu ubuntu bash -lc '
+cd /home/ubuntu/VinuChain-ops &&  # wherever this repo is cloned on-box
+./scripts/swap-testnet-opera.sh \
+  --target-dir /home/ubuntu/vinu-txtrace \
+  --expected-version 2.0.5-elemont
+'
+```
+
+The script will:
+
+1. Refuse to run as root.
+2. Require the target path to exist and contain `build/run_node.sh`.
+3. Refuse to proceed if `run_node.sh` lacks `--tracenode` (pass
+   `--skip-trace-check` only when swapping a validator or non-trace RPC).
+4. Refuse if an `opera` process is running from a path that doesn't match
+   the target. This is the 2026-04-17 failure mode.
+5. Verify `opera.new version` exactly matches `--expected-version`.
+6. Graceful SIGTERM with a 60-second budget; no force-kill.
+7. Back up the current binary to `build/opera.bak.<version>-<timestamp>`.
+8. Install the new binary and re-verify its reported version. If the
+   installed binary somehow reports the wrong version, roll back to the
+   backup and exit non-zero.
+9. Restart the node via `bash build/run_node.sh`.
+
+## Manual swap (if you cannot use the script)
+
+Only if the script itself is broken or unavailable.
+
+```bash
+# Under user ubuntu
+TARGET=/home/ubuntu/vinu-txtrace
+EXPECTED=2.0.5-elemont
+
+# 1. Sanity: is this the trace node?
+grep -- --tracenode "$TARGET/build/run_node.sh" >/dev/null \
+  || { echo "FATAL: target is NOT a trace checkout"; exit 1; }
+
+# 2. Version check on the candidate binary before stopping anything.
+"$TARGET/build/opera.new" version | grep -F "Version: $EXPECTED" \
+  || { echo "FATAL: new binary version != $EXPECTED"; exit 1; }
+
+# 3. Stop gracefully.
+pkill -TERM -u ubuntu -f '^'"$TARGET/build/opera"'( |$)' || true
+for i in $(seq 1 60); do pgrep -u ubuntu -f opera >/dev/null || break; sleep 1; done
+pgrep -u ubuntu -f opera >/dev/null && { echo "FATAL: opera still running"; exit 1; }
+
+# 4. Back up, install, verify.
+cp -p "$TARGET/build/opera" "$TARGET/build/opera.bak.manual-$(date -u +%Y%m%dT%H%M%SZ)"
+install -m 0755 "$TARGET/build/opera.new" "$TARGET/build/opera"
+"$TARGET/build/opera" version | grep -F "Version: $EXPECTED" \
+  || { echo "FATAL: installed binary version != $EXPECTED — roll back manually"; exit 1; }
+
+# 5. Restart.
+( cd "$TARGET/build" && bash run_node.sh )
+```
+
+## Post-swap verification
+
+1. `tail -F /home/ubuntu/vinu-txtrace/build/logs/*.log` — confirm block
+   production resumes within ~30 seconds.
+2. `curl -s -X POST http://localhost:18545 -H 'content-type: application/json' \
+   -d '{"jsonrpc":"2.0","id":1,"method":"web3_clientVersion","params":[]}'`
+   — response should include the new version string.
+3. Trace probe:
+   `curl -s -X POST http://localhost:18545 -H 'content-type: application/json' \
+   -d '{"jsonrpc":"2.0","id":1,"method":"debug_traceBlockByNumber","params":["latest",{"tracer":"callTracer"}]}'`
+   — must return a result, not `method not found`. If this fails you are
+   on a non-trace checkout.
+4. ALB target group (`ec2-vinu-new-alb-ec2`) goes back to healthy within a
+   few health check intervals.
+
+## Rollback
+
+Fast path (binary backup is on-disk):
+
+```bash
+cd /home/ubuntu/vinu-txtrace/build
+pkill -TERM -u ubuntu -f opera && sleep 10
+install -m 0755 opera.bak.<version>-<timestamp> opera
+bash run_node.sh
+```
+
+If the backup file is missing, rebuild the previous tag on the instance
+(same `git fetch --tags && git checkout <old-tag> && make opera` flow),
+rename `build/opera` to `build/opera.new`, and re-run the swap script.
+
+## Why each check exists
+
+| Check                          | Incident it prevents                                                                                          |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `--target-dir` required, no default | 2026-04-17 — swap landed in the wrong checkout because the path was implicit                           |
+| `--tracenode` presence guard   | Same incident — trace RPC silently dropped `debug_*`/`trace_*` support                                        |
+| Running-process path match     | Operator rebuilds in checkout A while node runs from checkout B; swap finishes, node never reloaded            |
+| Must run as `ubuntu`, not root | File ownership / systemd permission drift                                                                      |
+| Graceful SIGTERM, no force kill | LevelDB corruption from hard-killed opera mid-write                                                           |
+| Version string match before swap | Caller asked for `2.0.5-elemont` but built something else (wrong tag, uncommitted changes)                  |
+| Backup before install          | One-command rollback                                                                                           |
+| Version re-check after install | Catches partial `cp` / filesystem issues before the node restarts into an unknown state                       |
+
+## Known follow-ups
+
+- A sibling `scripts/swap-mainnet-opera.sh` (or a single script that takes
+  the role as a flag) is worth adding for `i-083fffeeb03583a18`. Mainnet
+  RPC has different path conventions and a larger chaindata footprint —
+  it warrants its own pre-flight (disk headroom, for one).
+- The same class of "ad-hoc SSM with empty `--comment`" will keep producing
+  this failure mode until the tooling that composes SSM commands is
+  required to include a comment and a target-path audit line.

--- a/scripts/swap-testnet-opera.sh
+++ b/scripts/swap-testnet-opera.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+#
+# swap-testnet-opera.sh — safely swap a freshly-built opera binary into a
+# running testnet node's checkout and restart it.
+#
+# Background: On 2026-04-17 a swap run against the testnet RPC instance
+# (i-0317eabd98fdf3951) targeted /home/ubuntu/VinuChain/build/ instead of
+# /home/ubuntu/vinu-txtrace/build/. The trace node needs --tracenode and
+# --db.preset pbl-1 to serve debug_* / trace_* RPCs; swapping the non-trace
+# checkout silently removed trace capability from the public RPC for hours.
+#
+# This script exists so that the swap logic lives somewhere persistent and
+# reviewable instead of in an ad-hoc SSM command body. Run it on the target
+# instance (via SSM send-command or an interactive ubuntu shell) — not from
+# the operator's workstation.
+#
+# Usage:
+#   swap-testnet-opera.sh --target-dir <path> --expected-version <semver> [options]
+#
+# Required flags:
+#   --target-dir <path>         Checkout whose build/opera is being swapped.
+#                               Example: /home/ubuntu/vinu-txtrace
+#   --expected-version <string> Version string the new binary must print, e.g.
+#                               "2.0.5-elemont". Compared against `opera version`.
+#
+# Optional flags:
+#   --source-bin <path>         Path to the newly-built binary. Defaults to
+#                               <target-dir>/build/opera.new (atomic staging).
+#   --skip-trace-check          Swap a non-trace checkout (mainnet RPC, validator).
+#                               MUST be supplied explicitly; the default is to
+#                               refuse if run_node.sh lacks --tracenode.
+#   --no-restart                Stop + swap but do not restart.
+#   -h, --help                  Print this help.
+#
+# Exit codes:
+#   0   success
+#   1   argument / pre-flight validation error
+#   2   target sanity check failed (wrong checkout, missing --tracenode, etc.)
+#   3   version mismatch
+#   4   runtime / swap failure
+#
+
+set -euo pipefail
+
+log() {
+	printf '[%s] %s\n' "$(date -u +%FT%TZ)" "$*" >&2
+}
+
+die() {
+	local code=$1
+	shift
+	log "FATAL: $*"
+	exit "$code"
+}
+
+usage() {
+	sed -n '3,38p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# --- Argument parsing -------------------------------------------------------
+
+TARGET_DIR=""
+EXPECTED_VERSION=""
+SOURCE_BIN=""
+SKIP_TRACE_CHECK=0
+RESTART=1
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--target-dir)
+			TARGET_DIR="${2:-}"
+			shift 2
+			;;
+		--expected-version)
+			EXPECTED_VERSION="${2:-}"
+			shift 2
+			;;
+		--source-bin)
+			SOURCE_BIN="${2:-}"
+			shift 2
+			;;
+		--skip-trace-check)
+			SKIP_TRACE_CHECK=1
+			shift
+			;;
+		--no-restart)
+			RESTART=0
+			shift
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			die 1 "unknown argument: $1 (see --help)"
+			;;
+	esac
+done
+
+[[ -n "$TARGET_DIR" ]] || die 1 "--target-dir is required (no default; state the target checkout explicitly)"
+[[ -n "$EXPECTED_VERSION" ]] || die 1 "--expected-version is required (e.g. 2.0.5-elemont)"
+
+[[ -d "$TARGET_DIR" ]] || die 1 "--target-dir does not exist: $TARGET_DIR"
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+
+BUILD_DIR="$TARGET_DIR/build"
+[[ -d "$BUILD_DIR" ]] || die 1 "no build/ under target-dir: $BUILD_DIR"
+
+RUN_NODE="$BUILD_DIR/run_node.sh"
+[[ -f "$RUN_NODE" ]] || die 1 "no run_node.sh under $BUILD_DIR"
+
+CURRENT_BIN="$BUILD_DIR/opera"
+[[ -x "$CURRENT_BIN" ]] || die 1 "no existing opera binary at $CURRENT_BIN (is this really a node checkout?)"
+
+if [[ -z "$SOURCE_BIN" ]]; then
+	SOURCE_BIN="$BUILD_DIR/opera.new"
+fi
+[[ -x "$SOURCE_BIN" ]] || die 1 "source binary missing or not executable: $SOURCE_BIN (build it first)"
+
+# --- Identity / environment pre-flight --------------------------------------
+
+# Refuse root. The node runs as ubuntu; swapping as root leaves files with
+# wrong ownership and can confuse systemd later.
+if [[ "$(id -u)" == "0" ]]; then
+	die 1 "do not run as root; re-invoke as user 'ubuntu'"
+fi
+
+if [[ "$(id -un)" != "ubuntu" ]]; then
+	die 1 "must run as user 'ubuntu' (got $(id -un))"
+fi
+
+log "target-dir       = $TARGET_DIR"
+log "build-dir        = $BUILD_DIR"
+log "run_node.sh      = $RUN_NODE"
+log "current binary   = $CURRENT_BIN"
+log "source binary    = $SOURCE_BIN"
+log "expected version = $EXPECTED_VERSION"
+
+# --- Checkout sanity: is this a trace node? ---------------------------------
+
+if grep -q -- '--tracenode' "$RUN_NODE"; then
+	HAS_TRACENODE=1
+else
+	HAS_TRACENODE=0
+fi
+
+if [[ "$HAS_TRACENODE" == "0" && "$SKIP_TRACE_CHECK" == "0" ]]; then
+	die 2 "target's run_node.sh does NOT contain '--tracenode'. This is the exact failure mode of the 2026-04-17 outage. If you are intentionally swapping a non-trace checkout (mainnet RPC, validator), pass --skip-trace-check. Target: $RUN_NODE"
+fi
+
+if [[ "$HAS_TRACENODE" == "1" ]]; then
+	log "OK: run_node.sh contains --tracenode"
+	# Warn if the db preset expected by trace nodes is missing.
+	if ! grep -q -- '--db.preset pbl-1' "$RUN_NODE"; then
+		log "WARNING: --tracenode present but '--db.preset pbl-1' not found in run_node.sh; double-check this is the right checkout"
+	fi
+else
+	log "non-trace checkout (confirmed via --skip-trace-check)"
+fi
+
+# --- Running-process sanity -------------------------------------------------
+
+# If opera is currently running, it must be the binary under this checkout.
+# Swapping while another opera instance runs from a different path is the
+# exact class of error we are guarding against.
+RUNNING_PIDS="$(pgrep -u ubuntu -f '[o]pera' 2>/dev/null || true)"
+if [[ -n "$RUNNING_PIDS" ]]; then
+	for pid in $RUNNING_PIDS; do
+		exe="$(readlink -f "/proc/$pid/exe" 2>/dev/null || true)"
+		if [[ -z "$exe" ]]; then
+			continue
+		fi
+		if [[ "$exe" != "$CURRENT_BIN" ]]; then
+			die 2 "an opera process (pid $pid) is running from $exe, which does not match $CURRENT_BIN. Refusing to swap — you are probably targeting the wrong checkout."
+		fi
+		log "running opera pid $pid → $exe (matches target) — OK"
+	done
+else
+	log "no opera process currently running under user ubuntu"
+fi
+
+# --- Version checks ---------------------------------------------------------
+
+# Current running binary's version — informational only.
+if current_version_output="$("$CURRENT_BIN" version 2>&1)"; then
+	current_version="$(printf '%s\n' "$current_version_output" | awk -F': ' '/^Version:/ {print $2; exit}')"
+	log "current binary reports version: ${current_version:-<unparseable>}"
+else
+	log "WARNING: current binary failed to report version (may be corrupt): $current_version_output"
+fi
+
+# New binary's version — must match --expected-version exactly.
+new_version_output="$("$SOURCE_BIN" version 2>&1)" || die 4 "new binary failed to run: $new_version_output"
+new_version="$(printf '%s\n' "$new_version_output" | awk -F': ' '/^Version:/ {print $2; exit}')"
+if [[ -z "$new_version" ]]; then
+	die 3 "could not parse Version: line from new binary output: $new_version_output"
+fi
+
+if [[ "$new_version" != "$EXPECTED_VERSION" ]]; then
+	die 3 "new binary version mismatch: expected '$EXPECTED_VERSION', got '$new_version'"
+fi
+log "OK: new binary reports version: $new_version"
+
+# --- Stop the node ----------------------------------------------------------
+
+if [[ -n "$RUNNING_PIDS" ]]; then
+	log "sending SIGTERM to opera pids: $RUNNING_PIDS"
+	kill -TERM $RUNNING_PIDS || true
+
+	# Wait up to 60s for graceful exit.
+	for _ in $(seq 1 60); do
+		if ! pgrep -u ubuntu -f '[o]pera' >/dev/null 2>&1; then
+			break
+		fi
+		sleep 1
+	done
+
+	if pgrep -u ubuntu -f '[o]pera' >/dev/null 2>&1; then
+		die 4 "opera did not exit within 60s of SIGTERM; refusing to force-kill (LevelDB corruption risk). Investigate manually."
+	fi
+	log "opera stopped cleanly"
+fi
+
+# --- Back up and swap -------------------------------------------------------
+
+backup_suffix="${current_version:-unknown}-$(date -u +%Y%m%dT%H%M%SZ)"
+backup_path="$BUILD_DIR/opera.bak.$backup_suffix"
+log "backing up current binary to $backup_path"
+cp -p "$CURRENT_BIN" "$backup_path"
+
+log "installing new binary at $CURRENT_BIN"
+install -m 0755 "$SOURCE_BIN" "$CURRENT_BIN"
+
+# Sanity: the installed binary must also report the expected version.
+installed_version_output="$("$CURRENT_BIN" version 2>&1)"
+installed_version="$(printf '%s\n' "$installed_version_output" | awk -F': ' '/^Version:/ {print $2; exit}')"
+if [[ "$installed_version" != "$EXPECTED_VERSION" ]]; then
+	log "installed binary version mismatch ($installed_version != $EXPECTED_VERSION) — rolling back"
+	install -m 0755 "$backup_path" "$CURRENT_BIN"
+	die 4 "rolled back to backup after version verification failure"
+fi
+log "OK: installed binary reports version: $installed_version"
+
+# --- Restart ----------------------------------------------------------------
+
+if [[ "$RESTART" == "0" ]]; then
+	log "--no-restart given; leaving node stopped"
+	log "swap complete; backup at $backup_path"
+	exit 0
+fi
+
+log "starting node via $RUN_NODE"
+cd "$BUILD_DIR"
+# run_node.sh is expected to background the node (nohup / &) itself. If it
+# blocks, the caller (SSM) will hang until the command times out — which is
+# the caller's problem, not this script's.
+bash "$RUN_NODE"
+
+log "swap complete; backup at $backup_path"


### PR DESCRIPTION
## Summary

- Adds `scripts/swap-testnet-opera.sh`, the first persisted, reviewable implementation of the opera-binary swap logic that was previously composed ad-hoc in SSM command bodies.
- Adds `scripts/SWAP-RUNBOOK.md` — the belt to the script's suspenders: same pre-flight, same guards, human-readable.
- Branched off `main` (not `elemont`) intentionally: this is ops tooling with no consensus or EVM impact, and the task calling for the fix specified a PR against `main`.

## Why

On **2026-04-17 ~15:41 UTC** an SSM swap command against testnet RPC (`i-0317eabd98fdf3951`) targeted `/home/ubuntu/VinuChain/build/` — a secondary non-trace checkout — instead of `/home/ubuntu/vinu-txtrace/build/`, which is the actual trace RPC checkout (`--tracenode --db.preset pbl-1`). Public `debug_*` / `trace_*` RPC silently stopped working until the correct checkout was identified and rebuilt.

Root cause: the swap logic lived nowhere persistent. No script, no SSM document, no runbook, no precondition guard. A fresh Claude session composed the SSM body from conversation context and picked the wrong path.

## What the script enforces

| Guard | Failure mode it prevents |
|---|---|
| `--target-dir` required, no default | Ambiguous / implicit target paths (the 2026-04-17 root cause) |
| `--tracenode` presence check (opt-out via `--skip-trace-check`) | Swapping a non-trace checkout on a host whose job is trace RPC |
| Running-process path match | Operator rebuilds in checkout A while node serves from checkout B |
| Refuse if `uid == 0`; require `ubuntu` | File ownership / systemd drift |
| `--expected-version` match before and after install | Wrong tag / uncommitted changes / partial install |
| Graceful SIGTERM with 60s budget, no force-kill | LevelDB corruption |
| Backup to `opera.bak.<version>-<ts>` before install | One-`install`-command rollback |
| Auto-rollback if installed version doesn't match expected | Filesystem / partial-copy regressions |

Smoke-tested locally against synthetic trace and non-trace checkouts: die(2) on missing `--tracenode`, die(3) on version mismatch, happy path installs + backs up + verifies.

## Test plan

- [ ] Human review of guard wording and exit-code taxonomy
- [ ] On a non-production staging host, invoke `swap-testnet-opera.sh --target-dir <trace-dir> --expected-version <next-tag>` end-to-end
- [ ] Confirm the rollback path works by deleting the new binary and running `install -m 0755 opera.bak.* opera`
- [ ] Follow-up (separate PR): sibling `swap-mainnet-opera.sh` for `i-083fffeeb03583a18`, which has different path conventions and larger chaindata