### PR TITLE
Unit 7 — RLP Patch4=false round-trip test

### DIFF
--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -249,6 +249,23 @@ func TestRulesSfcV2Patch4RLP(t *testing.T) {
 	require.True(decodedRules.Upgrades.SfcV2Patch4)
 }
 
+func TestRulesSfcV2Patch4FalseRLP(t *testing.T) {
+	rules := MainNetRules()
+	require := require.New(t)
+
+	// Sanity — this is the network that specifically does NOT enable Patch4.
+	require.False(rules.Upgrades.SfcV2Patch4, "MainNetRules should not have SfcV2Patch4 enabled; update this test if mainnet activates Patch4")
+
+	b, err := rlp.EncodeToBytes(rules)
+	require.NoError(err)
+
+	decodedRules := Rules{}
+	require.NoError(rlp.DecodeBytes(b, &decodedRules))
+
+	require.Equal(rules.String(), decodedRules.String())
+	require.False(decodedRules.Upgrades.SfcV2Patch4, "Upgrades.SfcV2Patch4 must round-trip as false through RLP")
+}
+
 func TestRulesBerlinCompatibilityRLP(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
## Summary
- Adds `TestRulesSfcV2Patch4FalseRLP` in `opera/marshal_test.go` to prove `Upgrades.SfcV2Patch4 == false` survives RLP encode/decode.
- Complements the existing `TestRulesSfcV2Patch4RLP` (true case via `VinuChainTestNetRules`) with the negative case via `MainNetRules()` — the production network that specifically does **not** enable Patch4 per the scaffolding commit.
- Provides the backward-compat signal: (a) encoding rules with Patch4 explicitly false does not spuriously flip the bit on decode, and (b) mainnet's post-elemont rules round-trip cleanly with the new bitmap position `1 << 9`.

## Why this shape
- Mirrors the sibling `TestRulesSfcV2Patch{2,3,4}RLP` pattern for grep-ability and house style.
- Adds a sanity `require.False` on the pre-encoded rules so the assertion's premise is self-documenting; failure message gives future maintainers a clear instruction if mainnet ever activates Patch4.
- Uses `MainNetRules()` directly (natural constructor) rather than explicit-clear on `VinuChainTestNetRules()` — more robust if the testnet constructor's Patch4 default ever changes.

## Test plan
- [x] `go test ./opera/ -run 'TestRulesSfcV2Patch4' -v` — both `TestRulesSfcV2Patch4RLP` (true) and new `TestRulesSfcV2Patch4FalseRLP` (false) pass.
- [x] `go test ./opera/...` — full opera package test suite green; no regressions.
- [ ] Reviewer: confirm base is `feat/sfc-v2-patch4-scaffolding` (NOT `elemont` / `main`).