### PR TITLE
Unit 8 — Patch4≠Patch3 + startup init() guard

### DIFF
--- a/cmd/opera/launcher/patch4_startup_check.go
+++ b/cmd/opera/launcher/patch4_startup_check.go
@@ -1,0 +1,24 @@
+package launcher
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/go-opera/opera/contracts/sfc"
+)
+
+// init wires the SfcV2Patch4 bytecode validity check into the opera binary's
+// startup so an invalid Patch4 asset (placeholder sentinel, all-zero, byte-
+// identical to Patch3, or below the minimum SFC size) refuses to start the
+// node rather than only crashing at the on-chain re-flash block.
+//
+// The check is skipped inside `go test` runs via testing.Testing() so that
+// the placeholder-still-present state of the scaffolding branch does not
+// break every test that transitively imports this package. At ship time,
+// when the real Cycle-160 bytecode lands in opera/contracts/sfc, the check
+// is a no-op regardless of context.
+func init() {
+	if testing.Testing() {
+		return
+	}
+	sfc.EnforcePatch4StartupCheck()
+}

--- a/opera/contracts/sfc/sfc_patch4_bytecode.go
+++ b/opera/contracts/sfc/sfc_patch4_bytecode.go
@@ -19,15 +19,22 @@ import (
 // PLACEHOLDER — real Cycle-160 bytecode drops in when vinuchain-lists PR #2
 // merges and is compiled with solc 0.5.17+commit.d19bba13 --optimize
 // --optimize-runs=10000 --evm-version=istanbul. Until then the bytes below
-// are a `deadbeef` sentinel, and the guard in validatePatch4Bytecode will
-// `log.Crit` at first attempted re-flash so a release cannot silently ship
-// the placeholder.
+// are a `deadbeef` sentinel. Validity is enforced at binary startup via
+// EnforcePatch4StartupCheck so an invalid asset refuses to start the node
+// rather than only crashing at the on-chain re-flash block.
 func GetPatch4ContractBin() []byte {
-	b := patch4PlaceholderBytecode
-	if err := validatePatch4Bytecode(b); err != nil {
-		log.Crit("SfcV2Patch4 bytecode is a placeholder — recompile from vinuchain-lists SFC.sol after PR #2 merges, then replace sfc_patch4_bytecode.go before cutting a release", "err", err)
+	return patch4PlaceholderBytecode
+}
+
+// EnforcePatch4StartupCheck validates the compiled-in Patch4 bytecode at
+// binary startup. It is wired from cmd/opera/launcher so the binary
+// refuses to start when the bytecode is still a placeholder or is byte-
+// identical to Patch3, rather than crashing only at the on-chain
+// re-flash block.
+func EnforcePatch4StartupCheck() {
+	if err := validatePatch4Bytecode(patch4PlaceholderBytecode); err != nil {
+		log.Crit("SfcV2Patch4 bytecode asset is invalid — the binary must not start with this build. Recompile SFC from vinuchain-lists and replace sfc_patch4_bytecode.go", "err", err)
 	}
-	return b
 }
 
 // patch4DeadbeefSentinel is the 4-byte magic pattern repeated throughout the
@@ -59,6 +66,8 @@ const minRealPatch4BytecodeLen = 10000
 //  2. anything shorter than minRealPatch4BytecodeLen
 //  3. a leading 0xdeadbeef prefix (sentinel marker)
 //  4. all-zero bytecode (paranoia guard; real compiled SFC is not all zero)
+//  5. byte-identical to Patch3 / GetContractBin (no-op re-flash would skip
+//     the lock-end-time fix)
 func validatePatch4Bytecode(code []byte) error {
 	if len(code) == 0 {
 		return errPatch4Empty
@@ -79,6 +88,9 @@ func validatePatch4Bytecode(code []byte) error {
 	if allZero {
 		return errPatch4AllZero
 	}
+	if bytes.Equal(code, GetContractBin()) {
+		return errPatch4EqualsPatch3
+	}
 	return nil
 }
 
@@ -87,8 +99,9 @@ type patch4Error string
 func (e patch4Error) Error() string { return string(e) }
 
 const (
-	errPatch4Empty    patch4Error = "patch4 bytecode is empty"
-	errPatch4TooShort patch4Error = "patch4 bytecode shorter than minimum SFC size — placeholder not replaced"
-	errPatch4Sentinel patch4Error = "patch4 bytecode begins with deadbeef sentinel — placeholder not replaced"
-	errPatch4AllZero  patch4Error = "patch4 bytecode is all zeros"
+	errPatch4Empty        patch4Error = "patch4 bytecode is empty"
+	errPatch4TooShort     patch4Error = "patch4 bytecode shorter than minimum SFC size — placeholder not replaced"
+	errPatch4Sentinel     patch4Error = "patch4 bytecode begins with deadbeef sentinel — placeholder not replaced"
+	errPatch4AllZero      patch4Error = "patch4 bytecode is all zeros"
+	errPatch4EqualsPatch3 patch4Error = "SfcV2Patch4 bytecode is byte-identical to Patch3 (Cycle-159) — the Patch4 re-flash would no-op on chain and the lock-end-time bug fix would not deploy"
 )

--- a/opera/contracts/sfc/sfc_patch4_bytecode_test.go
+++ b/opera/contracts/sfc/sfc_patch4_bytecode_test.go
@@ -60,3 +60,17 @@ func TestValidatePatch4Bytecode_AcceptsPlausibleReal(t *testing.T) {
 		t.Fatalf("validatePatch4Bytecode rejected plausible real bytecode: %v", err)
 	}
 }
+
+// TestValidatePatch4Bytecode_RejectsPatch3 asserts that shipping the Patch3
+// (Cycle-159) bytecode in the Patch4 slot is rejected. A byte-identical
+// re-flash would be a no-op on chain and the lock-end-time fix would not
+// deploy.
+func TestValidatePatch4Bytecode_RejectsPatch3(t *testing.T) {
+	err := validatePatch4Bytecode(GetContractBin())
+	if err == nil {
+		t.Fatal("validatePatch4Bytecode accepted Patch3 bytecode — a byte-identical re-flash would no-op on chain")
+	}
+	if err != errPatch4EqualsPatch3 {
+		t.Fatalf("expected errPatch4EqualsPatch3, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Hardens the `validatePatch4Bytecode` validator added by the scaffolding commit `19343b2`. Two gaps:

1. **Patch3 equality rejection.** If someone accidentally drops the Cycle-159 bytecode (what `GetContractBin()` returns — and what `SfcV2Patch3` already flashes on testnet) into the Patch4 slot, the current validator passes: ~45 KB is above the 10 KB minimum, doesn't start with `0xdeadbeef`, and isn't all zero. The re-flash would then be a no-op on chain and the lock-end-time fix would silently never deploy. New rejection path `errPatch4EqualsPatch3` via `bytes.Equal(code, GetContractBin())`.

2. **Startup-time enforcement.** The `log.Crit` that guarded the placeholder previously fired only inside `GetPatch4ContractBin()`, which is called at the on-chain re-flash block. A broken binary could therefore ship, boot, serve RPC for days, and crash only at activation. The check is now exposed as `sfc.EnforcePatch4StartupCheck()` and wired from `cmd/opera/launcher/patch4_startup_check.go` in `init()`. A binary built with an invalid Patch4 asset refuses to start.

## Design notes

- **Why `cmd/opera/launcher` init() and not `opera/contracts/sfc` init()?** Placing the guard in the sfc package would make `go test ./...` trip the check on every package that transitively imports sfc — every gossip test, every evmcore test, every integration test. Placing it in the launcher keeps the binary-refuses-to-start guarantee while scoping the blast radius to opera-main / opera-cmd only.
- **Why `testing.Testing()` guard in launcher init() instead of skipping init() entirely?** The launcher package has its own unit tests (`config_custom_test.go`, `run_test.go`, etc.) — if the init() fired during those, every launcher test would log.Crit out. `testing.Testing()` (Go 1.21+, we're on 1.25.8) is the canonical "am I running inside `go test`" check and is the cleanest way to keep the init() semantics while not breaking the test binary.
- **Why leave `GetPatch4ContractBin()` without defense-in-depth?** The startup check at init() time means any execution path that reaches `GetPatch4ContractBin()` has already passed validation. Keeping two copies of the log.Crit call would just confuse the "which site fired this?" diagnostic. Invariant: `GetPatch4ContractBin()` is only ever called in a process that has already passed `EnforcePatch4StartupCheck`.

## Test plan

- [x] `go test ./opera/contracts/sfc/... -run TestValidatePatch4Bytecode -v` — all 6 rejection/accepting paths pass, including the new `TestValidatePatch4Bytecode_RejectsPatch3`.
- [x] `go test ./opera/...` — all green, no regressions from the equality check.
- [x] `go test ./cmd/opera/launcher/...` — all green. `testing.Testing()` guard prevents the init() from tripping during test runs.
- [x] `make opera` — compiles cleanly.
- [x] `./build/opera version` with placeholder still present — `log.Crit`s with `err="patch4 bytecode shorter than minimum SFC size — placeholder not replaced"` and exits 1. This is the proof the startup check is wired.

## Not changed

- `patch4PlaceholderBytecode` remains the 256-byte `deadbeef` sentinel until the real Cycle-160 bytecode lands from vinuchain-lists PR #2.
- `sfcV2Patch4Bit = 1 << 9` and the `Upgrades.SfcV2Patch4` struct field are untouched.