### PR TITLE
fix(rpc): backport replay trace API to v2.0.0-rc.1

### DIFF
--- a/docs/mainnet-trace-rpc-hotfix-2026-05-17.md
+++ b/docs/mainnet-trace-rpc-hotfix-2026-05-17.md
@@ -1,0 +1,84 @@
+# Mainnet Trace RPC Hotfix - 2026-05-17
+
+This note records the mainnet RPC trace hotfix deployed for VinuExplorer
+internal native-transfer indexing.
+
+## Scope
+
+- Source baseline: `v2.0.0-rc.1`
+- Hotfix source commit: `60e43d6fa0f2a6d181fc6a0ef3fb897c709740df`
+- Provenance tag: `v2.0.0-rc.1-trace.1`
+- Review PR: `https://github.com/VinuChain/VinuChain/pull/14`
+- Mainnet RPC host: `i-083fffeeb03583a18` (`ip-10-0-142-137`)
+- Runtime binary: `/home/ubuntu/VinuChain/build/opera`
+- Rollback binary: `/home/ubuntu/VinuChain/build/opera.pre-trace-20260517T100059Z`
+- Built candidate SHA256:
+  `1ce6cd848046974958cc9ef9b23447f0b95d81d0ed9189d0e758062e5556ecda`
+
+The annotated tag intentionally points at the deployed source commit. Do not
+move `v2.0.0-rc.1-trace.1`. If code changes are needed after this note, build a
+new binary and tag a new source commit such as `v2.0.0-rc.1-trace.2`.
+
+## Behavior
+
+The hotfix registers the public `trace` RPC namespace and adds replay-backed
+support for:
+
+- `trace_block`
+- `trace_transaction`
+- `trace_get`
+
+VinuExplorer uses `trace_block` to index native internal transfers emitted by
+contracts. This fixed transaction
+`0xdd2007fae2f91fd0db5321a06097706c738ddc79d147e3f6eb4acb8153977b56`, where
+the splitter contract sent four native VC transfers that were not previously
+visible in explorer internal transactions.
+
+## Verification
+
+Live verification after deployment:
+
+- `web3_clientVersion`:
+  `go-opera/v2.0.0-rc.1-60e43d6f-1779011622/linux-amd64/go1.19.13`
+- `rpc_modules` includes `"trace": "1.0"`
+- `trace_block 0xcf1ae9` returns the target transaction and four child native
+  transfers from `0xda90cd8fb13370f5e720b2d6a5cd4b8459817f1f`
+- VinuExplorer mainnet backend imported block `13572841` and now serves those
+  internal transfers through `/api/v2/transactions/:hash/internal-transactions`
+
+Local build/test checks used for the source branch:
+
+```bash
+/usr/local/go/bin/go test ./ethapi ./txtrace ./gossip ./cmd/opera -run '^$'
+/usr/local/go/bin/go build -o build/opera-trace ./cmd/opera
+git diff --check
+```
+
+## Operational Constraints
+
+Trace replay is more expensive than ordinary read-only JSON-RPC calls. Keep
+public RPC access behind the existing proxy/rate-limit layer and monitor RPC
+latency, CPU, memory, and request volume after enabling any explorer backfill.
+
+Do not enable VinuExplorer's global internal-transaction fetcher while
+`pending_block_operations` contains a large historical backlog. Use the backend
+range tooling to prune or process bounded ranges first.
+
+## Rollback
+
+Rollback is a binary swap back to:
+
+```text
+/home/ubuntu/VinuChain/build/opera.pre-trace-20260517T100059Z
+```
+
+Before rollback, record current `web3_clientVersion`, service status, and the
+binary SHA256. After rollback, verify:
+
+- `vinu-opera.service` is running
+- public RPC responds to `eth_blockNumber`
+- `rpc_modules` no longer exposes unexpected namespaces
+- VinuExplorer backend health remains `200`
+
+Mainnet RPC swaps require explicit operator confirmation of target host, binary
+path, rollback path, and post-swap probes before execution.

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -133,6 +133,11 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 			Service:   NewPublicTxPoolAPI(apiBackend),
 			Public:    true,
 		}, {
+			Namespace: "trace",
+			Version:   "1.0",
+			Service:   NewPublicTxTraceAPI(apiBackend),
+			Public:    true,
+		}, {
 			Namespace: "debug",
 			Version:   "1.0",
 			Service:   NewPublicDebugAPI(apiBackend),

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -1,0 +1,308 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/Fantom-foundation/go-opera/evmcore"
+	"github.com/Fantom-foundation/go-opera/opera"
+	"github.com/Fantom-foundation/go-opera/opera/contracts/sfc"
+	"github.com/Fantom-foundation/go-opera/txtrace"
+	"github.com/Fantom-foundation/go-opera/utils/signers/gsignercache"
+)
+
+var zeroPayback = big.NewInt(0)
+
+// PublicTxTraceAPI provides an API to access transaction tracing.
+type PublicTxTraceAPI struct {
+	b Backend
+}
+
+// NewPublicTxTraceAPI creates a new transaction trace API.
+func NewPublicTxTraceAPI(b Backend) *PublicTxTraceAPI {
+	return &PublicTxTraceAPI{b}
+}
+
+// traceTx executes a single transaction with the trace logger enabled.
+func (s *PublicTxTraceAPI) traceTx(
+	ctx context.Context, msg types.Message,
+	state *state.StateDB, block *evmcore.EvmBlock, tx *types.Transaction, index uint64,
+	receipt *types.Receipt) (*[]txtrace.ActionTrace, error) {
+
+	cfg := opera.DefaultVMConfig
+	cfg.Debug = true
+	txTracer := txtrace.NewTraceStructLogger(nil)
+	cfg.Tracer = txTracer
+	cfg.NoBaseFee = true
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	txTracer.SetTx(tx.Hash())
+	txTracer.SetFrom(msg.From())
+	txTracer.SetTo(msg.To())
+	txTracer.SetValue(*msg.Value())
+	txTracer.SetBlockHash(block.Hash)
+	txTracer.SetBlockNumber(block.Number)
+	txTracer.SetTxIndex(uint(index))
+	txTracer.SetGasUsed(tx.Gas())
+
+	vmenv, _, err := s.b.GetEVM(ctx, msg, state, block.Header(), &cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		<-ctx.Done()
+		vmenv.Cancel()
+	}()
+
+	gp := new(evmcore.GasPool).AddGas(msg.Gas())
+	state.Prepare(tx.Hash(), int(index))
+	result, err := evmcore.ApplyMessage(vmenv, msg, gp, replayPayback(receipt))
+
+	if result != nil {
+		txTracer.SetGasUsed(result.UsedGas)
+	}
+	txTracer.ProcessTx()
+	traceActions := txTracer.GetTraceActions()
+	state.Finalise(true)
+	if err != nil {
+		errTrace := txtrace.GetErrorTraceFromMsg(&msg, block.Hash, *block.Number, tx.Hash(), index, err)
+		at := []txtrace.ActionTrace{*errTrace}
+		if receipt.Status == types.ReceiptStatusSuccessful {
+			log.Error("State mismatch replaying tx: failed but receipt shows success", "txHash", tx.Hash().String(), "err", err)
+			return nil, fmt.Errorf("state mismatch replaying tx %s: failed but receipt shows success", tx.Hash().String())
+		}
+		return &at, nil
+	}
+	if vmenv.Cancelled() {
+		log.Warn("EVM was canceled due to timeout when replaying transaction", "txHash", tx.Hash().String())
+		return nil, fmt.Errorf("timeout when replaying tx")
+	}
+	if result != nil && result.Err != nil {
+		if len(*traceActions) == 0 {
+			log.Error("error in result when replaying transaction", "txHash", tx.Hash().String(), "err", result.Err.Error())
+			errTrace := txtrace.GetErrorTraceFromMsg(&msg, block.Hash, *block.Number, tx.Hash(), index, result.Err)
+			return &[]txtrace.ActionTrace{*errTrace}, nil
+		}
+		if receipt.Status == types.ReceiptStatusSuccessful {
+			log.Error("State mismatch replaying tx: reverted but receipt shows success", "txHash", tx.Hash().String(), "err", result.Err)
+			return nil, fmt.Errorf("state mismatch replaying tx %s: reverted but receipt shows success", tx.Hash().String())
+		}
+		return traceActions, nil
+	}
+	if receipt.Status == types.ReceiptStatusFailed {
+		log.Error("State mismatch replaying tx: succeeded but receipt shows failure", "txHash", tx.Hash().String())
+		return nil, fmt.Errorf("state mismatch replaying tx %s: succeeded but receipt shows failure", tx.Hash().String())
+	}
+	return traceActions, nil
+}
+
+func replayPayback(receipt *types.Receipt) *big.Int {
+	if receipt == nil || receipt.FeeRefund == nil {
+		return zeroPayback
+	}
+	return new(big.Int).Set(receipt.FeeRefund)
+}
+
+func (s *PublicTxTraceAPI) replayTxWithoutTrace(ctx context.Context, msg types.Message, state *state.StateDB, block *evmcore.EvmBlock, tx *types.Transaction, index int, receipt *types.Receipt) error {
+	state.Prepare(tx.Hash(), index)
+	vmConfig := opera.DefaultVMConfig
+	vmConfig.NoBaseFee = true
+	vmConfig.Debug = false
+	vmConfig.Tracer = nil
+	vmenv, _, err := s.b.GetEVM(ctx, msg, state, block.Header(), &vmConfig)
+	if err != nil {
+		return err
+	}
+	res, applyErr := evmcore.ApplyMessage(vmenv, msg, new(evmcore.GasPool).AddGas(msg.Gas()), replayPayback(receipt))
+	failed := applyErr != nil
+	if applyErr != nil {
+		log.Error("Cannot replay transaction", "txHash", tx.Hash().String(), "err", applyErr.Error())
+	}
+	if res != nil && res.Err != nil {
+		failed = true
+		log.Debug("Error replaying transaction", "txHash", tx.Hash().String(), "err", res.Err.Error())
+	}
+	state.Finalise(true)
+	if (failed && receipt.Status == types.ReceiptStatusSuccessful) || (!failed && receipt.Status == types.ReceiptStatusFailed) {
+		log.Error("State mismatch replaying tx without trace", "txHash", tx.Hash().String())
+		return fmt.Errorf("state mismatch replaying tx %s", tx.Hash().String())
+	}
+	return nil
+}
+
+// traceBlock replays all transactions in the block and returns their traces.
+func (s *PublicTxTraceAPI) traceBlock(ctx context.Context, block *evmcore.EvmBlock, txHash *common.Hash, traceIndex *[]hexutil.Uint) (*[]txtrace.ActionTrace, error) {
+	var (
+		blockNumber   int64
+		parentBlockNr rpc.BlockNumber
+	)
+
+	if block == nil {
+		return nil, fmt.Errorf("invalid block for tracing")
+	}
+	blockNumber = block.Number.Int64()
+
+	callTrace := txtrace.CallTrace{
+		Actions: make([]txtrace.ActionTrace, 0),
+	}
+	if block.NumberU64() == 0 {
+		if len(block.Transactions) == 0 {
+			return &callTrace.Actions, nil
+		}
+		return nil, fmt.Errorf("cannot trace genesis block with transactions")
+	}
+	parentBlockNr = rpc.BlockNumber(blockNumber - 1)
+
+	if s.b.CurrentBlock().Number.Int64() < blockNumber {
+		return nil, fmt.Errorf("invalid block %v for tracing, current block is %v", blockNumber, s.b.CurrentBlock())
+	}
+
+	signer := gsignercache.Wrap(types.MakeSigner(s.b.ChainConfig(), block.Number))
+	stateDB, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, rpc.BlockNumberOrHash{BlockNumber: &parentBlockNr})
+	if err != nil {
+		return nil, fmt.Errorf("cannot get state for block %v, error: %v", block.NumberU64(), err.Error())
+	}
+	receipts, err := s.b.GetReceiptsByNumber(ctx, rpc.BlockNumber(blockNumber))
+	if err != nil {
+		log.Debug("Cannot get receipts for block", "block", blockNumber, "err", err.Error())
+		return nil, fmt.Errorf("cannot get receipts for block %v, error: %v", block.NumberU64(), err.Error())
+	}
+	if len(receipts) != len(block.Transactions) {
+		return nil, fmt.Errorf("receipt count mismatch for block %d: %d txs but %d receipts", blockNumber, len(block.Transactions), len(receipts))
+	}
+
+	for i, tx := range block.Transactions {
+		if txHash == nil || *txHash == tx.Hash() {
+			log.Debug("Replaying transaction", "txHash", tx.Hash().String())
+			index := uint64(i)
+			msg, err := evmcore.TxAsMessage(tx, signer, block.BaseFee)
+			if err != nil {
+				callTrace.AddTrace(txtrace.GetErrorTrace(block.Hash, *block.Number, nil, tx.To(), tx.Hash(), index, errors.New("not able to decode tx")))
+				continue
+			}
+			from := msg.From()
+			if tx.To() != nil && *tx.To() == sfc.ContractAddress {
+				if err := s.replayTxWithoutTrace(ctx, msg, stateDB, block, tx, i, receipts[i]); err != nil {
+					return nil, err
+				}
+				callTrace.AddTrace(txtrace.GetErrorTrace(block.Hash, *block.Number, &from, tx.To(), tx.Hash(), index, errors.New("sfc tx")))
+			} else {
+				txTraces, err := s.traceTx(ctx, msg, stateDB, block, tx, index, receipts[i])
+				if err != nil {
+					log.Debug("Cannot get transaction trace", "txHash", tx.Hash().String(), "err", err.Error())
+					callTrace.AddTrace(txtrace.GetErrorTraceFromMsg(&msg, block.Hash, *block.Number, tx.Hash(), index, err))
+				} else {
+					callTrace.AddTraces(txTraces, traceIndex)
+				}
+			}
+			if txHash != nil {
+				break
+			}
+		} else {
+			log.Debug("Replaying transaction without trace", "txHash", tx.Hash().String())
+			msg, err := evmcore.TxAsMessage(tx, signer, block.BaseFee)
+			if err != nil {
+				return nil, fmt.Errorf("cannot decode tx %s: %w", tx.Hash().String(), err)
+			}
+			if err := s.replayTxWithoutTrace(ctx, msg, stateDB, block, tx, i, receipts[i]); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if len(callTrace.Actions) == 0 {
+		return &callTrace.Actions, nil
+	}
+
+	return &callTrace.Actions, nil
+}
+
+// Block implements trace_block: returns all transaction traces in the given block.
+func (s *PublicTxTraceAPI) Block(ctx context.Context, numberOrHash rpc.BlockNumberOrHash) (*[]txtrace.ActionTrace, error) {
+	blockNr, _ := numberOrHash.Number()
+	defer func(start time.Time) {
+		log.Debug("Executing trace_block call finished", "blockNr", blockNr.Int64(), "runtime", time.Since(start))
+	}(time.Now())
+
+	var (
+		block *evmcore.EvmBlock
+		err   error
+	)
+	if blockHash, ok := numberOrHash.Hash(); ok {
+		block, err = s.b.BlockByHash(ctx, blockHash)
+	} else {
+		block, err = s.b.BlockByNumber(ctx, blockNr)
+	}
+	if err != nil {
+		log.Debug("Cannot get block from db", "blockNr", blockNr)
+		return nil, err
+	}
+	if block == nil {
+		return nil, fmt.Errorf("block not found")
+	}
+	return s.traceBlock(ctx, block, nil, nil)
+}
+
+// Transaction implements trace_transaction: returns traces for a single transaction.
+func (s *PublicTxTraceAPI) Transaction(ctx context.Context, hash common.Hash) (*[]txtrace.ActionTrace, error) {
+	defer func(start time.Time) {
+		log.Debug("Executing trace_transaction call finished", "txHash", hash.String(), "runtime", time.Since(start))
+	}(time.Now())
+	return s.traceTxHash(ctx, hash, nil)
+}
+
+// Get implements trace_get: returns the trace at the specified index position.
+func (s *PublicTxTraceAPI) Get(ctx context.Context, hash common.Hash, traceIndex []hexutil.Uint) (*txtrace.ActionTrace, error) {
+	defer func(start time.Time) {
+		log.Debug("Executing trace_get call finished", "txHash", hash.String(), "index", traceIndex, "runtime", time.Since(start))
+	}(time.Now())
+	traces, err := s.traceTxHash(ctx, hash, &traceIndex)
+	if err != nil || traces == nil || len(*traces) == 0 {
+		return nil, err
+	}
+	return &(*traces)[0], nil
+}
+
+func (s *PublicTxTraceAPI) traceTxHash(ctx context.Context, hash common.Hash, traceIndex *[]hexutil.Uint) (*[]txtrace.ActionTrace, error) {
+	tx, blockNumber, _, _ := s.b.GetTransaction(ctx, hash)
+	if tx == nil {
+		return nil, fmt.Errorf("transaction not found: %s", hash.Hex())
+	}
+	blkNr := rpc.BlockNumber(blockNumber)
+	block, err := s.b.BlockByNumber(ctx, blkNr)
+	if err != nil {
+		log.Debug("Cannot get block from db", "blockNr", blkNr)
+		return nil, err
+	}
+	return s.traceBlock(ctx, block, &hash, traceIndex)
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
 	github.com/holiman/bloomfilter/v2 v2.0.3
+	github.com/holiman/uint256 v1.2.0
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/txtrace/trace_logger.go
+++ b/txtrace/trace_logger.go
@@ -1,0 +1,637 @@
+package txtrace
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/holiman/uint256"
+)
+
+// TraceStructLogger is a transaction trace creator.
+type TraceStructLogger struct {
+	from        *common.Address
+	to          *common.Address
+	newAddress  *common.Address
+	blockHash   common.Hash
+	tx          common.Hash
+	txIndex     uint
+	blockNumber big.Int
+	value       big.Int
+
+	gasUsed      uint64
+	feeRefund    *big.Int
+	rootTrace    *CallTrace
+	inputData    []byte
+	state        []depthState
+	traceAddress []uint32
+	stack        []*big.Int
+	reverted     bool
+	output       []byte
+	err          error
+}
+
+// NewTraceStructLogger creates a new instance of the trace creator.
+func NewTraceStructLogger(_ interface{}) *TraceStructLogger {
+	return &TraceStructLogger{
+		stack: make([]*big.Int, 30),
+	}
+}
+
+// CaptureStart implements the tracer interface to initialize the tracing operation.
+func (tr *TraceStructLogger) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("Tracer CaptureStart failed", "recover", fmt.Sprintf("%v", r))
+		}
+	}()
+	txTrace := CallTrace{
+		Actions: make([]ActionTrace, 0),
+	}
+
+	callType := CREATE
+	var newAddress *common.Address
+	if tr.to != nil {
+		callType = CALL
+	} else {
+		newAddress = &to
+	}
+
+	tr.inputData = input
+	if gas == 0 && tr.gasUsed != 0 {
+		gas = tr.gasUsed
+	}
+
+	blockTrace := NewActionTrace(tr.blockHash, tr.blockNumber, tr.tx, uint64(tr.txIndex), callType)
+	var txAction *AddressAction
+	if CREATE == callType {
+		txAction = NewAddressAction(tr.from, gas, tr.inputData, nil, hexutil.Big(tr.value), nil)
+		if newAddress != nil {
+			blockTrace.Result.Address = newAddress
+			code := hexutil.Bytes(tr.output)
+			blockTrace.Result.Code = &code
+		}
+	} else {
+		txAction = NewAddressAction(tr.from, gas, tr.inputData, tr.to, hexutil.Big(tr.value), &callType)
+		out := hexutil.Bytes(tr.output)
+		blockTrace.Result.Output = &out
+	}
+	blockTrace.Action = txAction
+
+	txTrace.AddTrace(blockTrace)
+	tr.rootTrace = &txTrace
+
+	tr.state = []depthState{{0, create}}
+	tr.traceAddress = make([]uint32, 0)
+	tr.rootTrace.Stack = append(tr.rootTrace.Stack, &tr.rootTrace.Actions[len(tr.rootTrace.Actions)-1])
+}
+
+// stackPosFromEnd returns the stack element at the given position from the end.
+func stackPosFromEnd(stackData []uint256.Int, pos int) *big.Int {
+	if len(stackData) <= pos || pos < 0 {
+		log.Warn("Tracer accessed out of bound stack", "size", len(stackData), "index", pos)
+		return new(big.Int)
+	}
+	return new(big.Int).Set(stackData[len(stackData)-1-pos].ToBig())
+}
+
+// CaptureState implements creating of traces based on EVM opcode execution.
+func (tr *TraceStructLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("Tracer CaptureState failed", "recover", fmt.Sprintf("%v", r))
+		}
+	}()
+	// COR-005: guard against nil rootTrace (CaptureStart never called or panicked
+	// before initializing rootTrace).
+	if tr.rootTrace == nil {
+		return
+	}
+	// COR-001: guard Stack length in drain loop; Stack and state can desync if
+	// CaptureStart panicked after setting state but before pushing to Stack.
+	for len(tr.state) > 0 && len(tr.rootTrace.Stack) > 0 && lastState(tr.state).level >= depth {
+		result := tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1].Result
+		if lastState(tr.state).create && result != nil {
+			if len(scope.Stack.Data()) > 0 {
+				addr := common.BytesToAddress(stackPosFromEnd(scope.Stack.Data(), 0).Bytes())
+				result.Address = &addr
+				result.GasUsed = hexutil.Uint64(gas)
+			}
+		}
+		tr.traceAddress = removeTraceAddressLevel(tr.traceAddress, depth)
+		tr.state = tr.state[:len(tr.state)-1]
+		tr.rootTrace.Stack = tr.rootTrace.Stack[:len(tr.rootTrace.Stack)-1]
+		if len(tr.state) == 0 || lastState(tr.state).level == depth {
+			break
+		}
+	}
+	// COR-001: if the drain loop emptied the Stack, no switch case can safely
+	// access Stack[len-1]; return early to avoid a panic.
+	if len(tr.rootTrace.Stack) == 0 {
+		return
+	}
+
+	switch op {
+	case vm.CREATE, vm.CREATE2:
+		tr.traceAddress = addTraceAddress(tr.traceAddress, depth)
+		fromTrace := tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1]
+
+		value := stackPosFromEnd(scope.Stack.Data(), 0)
+		offset := stackPosFromEnd(scope.Stack.Data(), 1).Uint64()
+		inputSize := stackPosFromEnd(scope.Stack.Data(), 2).Uint64()
+		var input []byte
+		if inputSize > 0 {
+			if offset <= offset+inputSize &&
+				offset+inputSize <= uint64(len(scope.Memory.Data())) {
+				input = make([]byte, inputSize)
+				copy(input, scope.Memory.Data()[offset:offset+inputSize])
+			}
+		}
+
+		trace := NewActionTraceFromTrace(fromTrace, CREATE, tr.traceAddress)
+		from := scope.Contract.Address()
+		traceAction := NewAddressAction(&from, gas, input, nil, hexutil.Big(*value), nil)
+		trace.Action = traceAction
+		trace.Result.GasUsed = hexutil.Uint64(gas)
+		fromTrace.childTraces = append(fromTrace.childTraces, trace)
+		tr.rootTrace.Stack = append(tr.rootTrace.Stack, trace)
+		tr.state = append(tr.state, depthState{depth, true})
+
+	case vm.CALL, vm.CALLCODE, vm.DELEGATECALL, vm.STATICCALL:
+		var (
+			inOffset, inSize uint64
+			input            []byte
+			value            = big.NewInt(0)
+		)
+
+		if vm.DELEGATECALL == op || vm.STATICCALL == op {
+			inOffset = stackPosFromEnd(scope.Stack.Data(), 2).Uint64()
+			inSize = stackPosFromEnd(scope.Stack.Data(), 3).Uint64()
+		} else {
+			inOffset = stackPosFromEnd(scope.Stack.Data(), 3).Uint64()
+			inSize = stackPosFromEnd(scope.Stack.Data(), 4).Uint64()
+			value = stackPosFromEnd(scope.Stack.Data(), 2)
+		}
+		if inSize > 0 {
+			if inOffset <= inOffset+inSize &&
+				inOffset+inSize <= uint64(len(scope.Memory.Data())) {
+				input = make([]byte, inSize)
+				copy(input, scope.Memory.Data()[inOffset:inOffset+inSize])
+			}
+		}
+		tr.traceAddress = addTraceAddress(tr.traceAddress, depth)
+		fromTrace := tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1]
+		trace := NewActionTraceFromTrace(fromTrace, CALL, tr.traceAddress)
+		from := scope.Contract.Address()
+		addr := common.BytesToAddress(stackPosFromEnd(scope.Stack.Data(), 1).Bytes())
+		callType := strings.ToLower(op.String())
+		traceAction := NewAddressAction(&from, gas, input, &addr, hexutil.Big(*value), &callType)
+		trace.Action = traceAction
+		fromTrace.childTraces = append(fromTrace.childTraces, trace)
+		tr.rootTrace.Stack = append(tr.rootTrace.Stack, trace)
+		tr.state = append(tr.state, depthState{depth, false})
+
+	case vm.RETURN, vm.STOP:
+		if tr != nil {
+			result := tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1].Result
+			if result != nil {
+				var data []byte
+				if vm.STOP != op {
+					offset := stackPosFromEnd(scope.Stack.Data(), 0).Uint64()
+					size := stackPosFromEnd(scope.Stack.Data(), 1).Uint64()
+					if size > 0 {
+						if offset <= offset+size &&
+							offset+size <= uint64(len(scope.Memory.Data())) {
+							data = make([]byte, size)
+							copy(data, scope.Memory.Data()[offset:offset+size])
+						}
+					}
+				}
+				// COR-002: state may be empty after the drain loop; guard before
+				// calling lastState to avoid an out-of-bounds access.
+				if len(tr.state) > 0 && lastState(tr.state).create {
+					code := hexutil.Bytes(data)
+					result.Code = &code
+				} else {
+					result.GasUsed = hexutil.Uint64(gas)
+					out := hexutil.Bytes(data)
+					result.Output = &out
+				}
+			}
+		}
+
+	case vm.REVERT:
+		tr.reverted = true
+		tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1].Result = nil
+		tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1].Error = "Reverted"
+
+	case vm.SELFDESTRUCT:
+		tr.traceAddress = addTraceAddress(tr.traceAddress, depth)
+		fromTrace := tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1]
+		trace := NewActionTraceFromTrace(fromTrace, SELFDESTRUCT, tr.traceAddress)
+		action := fromTrace.Action
+
+		from := scope.Contract.Address()
+		traceAction := NewAddressAction(nil, 0, nil, nil, action.Value, nil)
+		traceAction.Address = &from
+		refundAddress := common.BytesToAddress(stackPosFromEnd(scope.Stack.Data(), 0).Bytes())
+		traceAction.RefundAddress = &refundAddress
+		traceAction.Balance = &traceAction.Value
+		trace.Action = traceAction
+		fromTrace.childTraces = append(fromTrace.childTraces, trace)
+	}
+}
+
+// CaptureEnd is called after the call finishes to finalize the tracing.
+func (tr *TraceStructLogger) CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("Tracer CaptureEnd failed", "recover", fmt.Sprintf("%v", r))
+		}
+	}()
+	log.Debug("TraceStructLogger capture END", "tx hash", tr.tx.String(), "duration", t, "gasUsed", gasUsed, "error", err)
+	if err != nil && err != vm.ErrExecutionReverted {
+		if tr.rootTrace != nil && tr.rootTrace.Stack != nil && len(tr.rootTrace.Stack) > 0 {
+			tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1].Result = nil
+			tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1].Error = err.Error()
+		}
+	}
+	if gasUsed > 0 {
+		if tr.rootTrace != nil && len(tr.rootTrace.Actions) > 0 {
+			if tr.rootTrace.Actions[0].Result != nil {
+				tr.rootTrace.Actions[0].Result.GasUsed = hexutil.Uint64(gasUsed)
+			}
+			tr.rootTrace.lastTrace().Action.Gas = hexutil.Uint64(gasUsed)
+		}
+		tr.gasUsed = gasUsed
+	}
+	tr.output = output
+}
+
+// CaptureEnter is called when entering an inner call frame.
+func (*TraceStructLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+}
+
+// CaptureExit is called when returning from an inner call frame.
+func (tr *TraceStructLogger) CaptureExit(output []byte, gasUsed uint64, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("Tracer CaptureExit failed", "recover", fmt.Sprintf("%v", r))
+		}
+	}()
+	if tr.rootTrace == nil || len(tr.rootTrace.Stack) == 0 {
+		return
+	}
+	result := tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1].Result
+	if result != nil {
+		result.GasUsed = hexutil.Uint64(gasUsed)
+		out := hexutil.Bytes(output)
+		result.Output = &out
+	}
+}
+
+// CaptureFault implements the Tracer interface to trace an execution fault.
+func (tr *TraceStructLogger) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
+}
+
+func (tr *TraceStructLogger) reset() {
+	tr.to = nil
+	tr.from = nil
+	tr.inputData = nil
+	tr.rootTrace = nil
+	tr.reverted = false
+	tr.output = nil
+	tr.gasUsed = 0
+	tr.feeRefund = nil
+	tr.err = nil
+	tr.state = nil
+	tr.traceAddress = nil
+	tr.stack = tr.stack[:0]
+}
+
+// SetTx prepares the logger for a new transaction. It clears any stale state
+// from a prior transaction (including state left by a mid-capture panic) before
+// recording the new hash, so a failed previous capture cannot contaminate this tx.
+func (tr *TraceStructLogger) SetTx(tx common.Hash) {
+	tr.reset()
+	tr.tx = tx
+}
+
+// SetFrom sets the sender address.
+func (tr *TraceStructLogger) SetFrom(from common.Address) { tr.from = &from }
+
+// SetTo sets the recipient address.
+func (tr *TraceStructLogger) SetTo(to *common.Address) { tr.to = to }
+
+// SetValue sets the transaction value.
+func (tr *TraceStructLogger) SetValue(value big.Int) { tr.value = value }
+
+// SetBlockHash sets the block hash.
+func (tr *TraceStructLogger) SetBlockHash(blockHash common.Hash) { tr.blockHash = blockHash }
+
+// SetBlockNumber sets the block number.
+func (tr *TraceStructLogger) SetBlockNumber(blockNumber *big.Int) { tr.blockNumber = *blockNumber }
+
+// SetTxIndex sets the transaction index within the block.
+func (tr *TraceStructLogger) SetTxIndex(txIndex uint) { tr.txIndex = txIndex }
+
+// SetNewAddress sets the created contract address.
+func (tr *TraceStructLogger) SetNewAddress(newAddress common.Address) {
+	tr.newAddress = &newAddress
+}
+
+// SetGasUsed sets the gas used by the transaction.
+func (tr *TraceStructLogger) SetGasUsed(gasUsed uint64) { tr.gasUsed = gasUsed }
+
+// SetFeeRefund sets the fee refund amount for the transaction.
+func (tr *TraceStructLogger) SetFeeRefund(feeRefund *big.Int) { tr.feeRefund = feeRefund }
+
+// ProcessTx finalizes trace processing.
+func (tr *TraceStructLogger) ProcessTx() {
+	if tr.rootTrace != nil {
+		tr.rootTrace.lastTrace().Action.Gas = hexutil.Uint64(tr.gasUsed)
+		if tr.rootTrace.lastTrace().Result != nil {
+			tr.rootTrace.lastTrace().Result.GasUsed = hexutil.Uint64(tr.gasUsed)
+		}
+		tr.rootTrace.processLastTrace()
+	}
+}
+
+// SaveTrace finalizes the logger state for callers that share the newer tracer
+// interface. This backport only replays traces on demand, so there is no trace
+// store to persist into.
+func (tr *TraceStructLogger) SaveTrace() {
+	defer tr.reset()
+	if tr.rootTrace == nil {
+		tr.rootTrace = &CallTrace{}
+		tr.rootTrace.AddTrace(GetErrorTraceFromLogger(tr))
+	}
+	if tr.feeRefund != nil && len(tr.rootTrace.Actions) > 0 {
+		tr.rootTrace.Actions[0].FeeRefund = (*hexutil.Big)(tr.feeRefund)
+	}
+}
+
+// GetTraceActions returns the collected action traces.
+func (tr *TraceStructLogger) GetTraceActions() *[]ActionTrace {
+	if tr.rootTrace != nil {
+		return &tr.rootTrace.Actions
+	}
+	empty := make([]ActionTrace, 0)
+	return &empty
+}
+
+// CallTrace holds the full set of traces for a transaction.
+type CallTrace struct {
+	Actions []ActionTrace  `json:"result"`
+	Stack   []*ActionTrace `json:"-"`
+}
+
+// AddTrace appends a trace to the call trace list.
+func (callTrace *CallTrace) AddTrace(blockTrace *ActionTrace) {
+	if callTrace.Actions == nil {
+		callTrace.Actions = make([]ActionTrace, 0)
+	}
+	callTrace.Actions = append(callTrace.Actions, *blockTrace)
+}
+
+// AddTraces appends traces matching the optional index filter.
+func (callTrace *CallTrace) AddTraces(traces *[]ActionTrace, traceIndex *[]hexutil.Uint) {
+	for _, trace := range *traces {
+		if traceIndex == nil || equalContent(traceIndex, trace.TraceAddress) {
+			callTrace.AddTrace(&trace)
+		}
+	}
+}
+
+func equalContent(index *[]hexutil.Uint, traceIndex []uint32) bool {
+	if len(*index) != len(traceIndex) {
+		return false
+	}
+	for i, v := range *index {
+		if uint32(v) != traceIndex[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (callTrace *CallTrace) lastTrace() *ActionTrace {
+	if len(callTrace.Actions) > 0 {
+		return &callTrace.Actions[len(callTrace.Actions)-1]
+	}
+	return nil
+}
+
+// NewActionTrace creates a new ActionTrace instance.
+func NewActionTrace(bHash common.Hash, bNumber big.Int, tHash common.Hash, tPos uint64, tType string) *ActionTrace {
+	return &ActionTrace{
+		BlockHash:           bHash,
+		BlockNumber:         bNumber,
+		TransactionHash:     tHash,
+		TransactionPosition: tPos,
+		TraceType:           tType,
+		TraceAddress:        make([]uint32, 0),
+		Result:              &TraceActionResult{},
+	}
+}
+
+// NewActionTraceFromTrace creates an ActionTrace derived from an existing one.
+func NewActionTraceFromTrace(actionTrace *ActionTrace, tType string, traceAddress []uint32) *ActionTrace {
+	trace := NewActionTrace(
+		actionTrace.BlockHash,
+		actionTrace.BlockNumber,
+		actionTrace.TransactionHash,
+		actionTrace.TransactionPosition,
+		tType)
+	trace.TraceAddress = traceAddress
+	return trace
+}
+
+const (
+	CALL         = "call"
+	CREATE       = "create"
+	SELFDESTRUCT = "suicide"
+)
+
+// ActionTrace represents a single interaction with the blockchain.
+type ActionTrace struct {
+	childTraces         []*ActionTrace     `json:"-"`
+	Action              *AddressAction     `json:"action"`
+	BlockHash           common.Hash        `json:"blockHash"`
+	BlockNumber         big.Int            `json:"blockNumber"`
+	Result              *TraceActionResult `json:"result,omitempty"`
+	Error               string             `json:"error,omitempty"`
+	FeeRefund           *hexutil.Big       `json:"feeRefund,omitempty"`
+	Subtraces           uint64             `json:"subtraces"`
+	TraceAddress        []uint32           `json:"traceAddress"`
+	TransactionHash     common.Hash        `json:"transactionHash"`
+	TransactionPosition uint64             `json:"transactionPosition"`
+	TraceType           string             `json:"type"`
+}
+
+// NewAddressAction creates an AddressAction with the given parameters.
+func NewAddressAction(from *common.Address, gas uint64, data []byte, to *common.Address, value hexutil.Big, callType *string) *AddressAction {
+	action := AddressAction{
+		From:     from,
+		To:       to,
+		Gas:      hexutil.Uint64(gas),
+		Value:    value,
+		CallType: callType,
+	}
+	inputHex := hexutil.Bytes(common.CopyBytes(data))
+	if callType == nil {
+		action.Init = &inputHex
+	} else {
+		action.Input = &inputHex
+	}
+	return &action
+}
+
+// AddressAction contains the details of a call or create action.
+type AddressAction struct {
+	CallType      *string         `json:"callType,omitempty"`
+	From          *common.Address `json:"from"`
+	To            *common.Address `json:"to,omitempty"`
+	Value         hexutil.Big     `json:"value"`
+	Gas           hexutil.Uint64  `json:"gas"`
+	Init          *hexutil.Bytes  `json:"init,omitempty"`
+	Input         *hexutil.Bytes  `json:"input,omitempty"`
+	Address       *common.Address `json:"address,omitempty"`
+	RefundAddress *common.Address `json:"refund_address,omitempty"`
+	Balance       *hexutil.Big    `json:"balance,omitempty"`
+}
+
+// TraceActionResult holds the result of a traced action.
+type TraceActionResult struct {
+	GasUsed   hexutil.Uint64  `json:"gasUsed"`
+	Output    *hexutil.Bytes  `json:"output,omitempty"`
+	Code      *hexutil.Bytes  `json:"code,omitempty"`
+	Address   *common.Address `json:"address,omitempty"`
+	RetOffset uint64          `json:"-"`
+	RetSize   uint64          `json:"-"`
+}
+
+type depthState struct {
+	level  int
+	create bool
+}
+
+func lastState(state []depthState) *depthState {
+	return &state[len(state)-1]
+}
+
+func addTraceAddress(traceAddress []uint32, depth int) []uint32 {
+	index := depth - 1
+	result := make([]uint32, len(traceAddress))
+	copy(result, traceAddress)
+	if len(result) <= index {
+		result = append(result, 0)
+	} else {
+		result[index]++
+	}
+	return result
+}
+
+func removeTraceAddressLevel(traceAddress []uint32, depth int) []uint32 {
+	if len(traceAddress) > depth {
+		result := make([]uint32, len(traceAddress))
+		copy(result, traceAddress)
+		result = result[:len(result)-1]
+		return result
+	}
+	return traceAddress
+}
+
+func (callTrace *CallTrace) processLastTrace() {
+	trace := &callTrace.Actions[len(callTrace.Actions)-1]
+	callTrace.processTrace(trace)
+}
+
+func (callTrace *CallTrace) processTrace(trace *ActionTrace) {
+	// Snapshot all fields from trace before any AddTrace call, since appending
+	// to callTrace.Actions may reallocate the backing array, invalidating the
+	// pointer for the next loop iteration.
+	traceType := trace.TraceType
+	actionTo := trace.Action.To
+	actionGas := trace.Action.Gas
+	var resultFrom *common.Address
+	if trace.Result != nil {
+		resultFrom = trace.Result.Address
+	}
+	childTraces := trace.childTraces
+	trace.Subtraces = uint64(len(childTraces))
+
+	for _, childTrace := range childTraces {
+		if CALL == traceType {
+			childTrace.Action.From = actionTo
+		} else {
+			childTrace.Action.From = resultFrom
+		}
+		if childTrace.Result != nil {
+			if actionGas > childTrace.Result.GasUsed {
+				childTrace.Action.Gas = actionGas - childTrace.Result.GasUsed
+			} else {
+				childTrace.Action.Gas = childTrace.Result.GasUsed
+			}
+		}
+		callTrace.AddTrace(childTrace)
+		callTrace.processTrace(callTrace.lastTrace())
+	}
+}
+
+// GetErrorTrace constructs a filled error trace from explicit parameters.
+func GetErrorTrace(blockHash common.Hash, blockNumber big.Int, from *common.Address, to *common.Address, txHash common.Hash, index uint64, err error) *ActionTrace {
+	return createErrorTrace(blockHash, blockNumber, from, to, txHash, 0, []byte{}, hexutil.Big{}, index, err)
+}
+
+// GetErrorTraceFromLogger constructs a filled error trace from a TraceStructLogger.
+func GetErrorTraceFromLogger(tr *TraceStructLogger) *ActionTrace {
+	if tr == nil {
+		return nil
+	}
+	return createErrorTrace(tr.blockHash, tr.blockNumber, tr.from, tr.to, tr.tx, tr.gasUsed, tr.inputData, hexutil.Big(tr.value), uint64(tr.txIndex), tr.err)
+}
+
+// GetErrorTraceFromMsg constructs a filled error trace from a transaction message.
+func GetErrorTraceFromMsg(msg *types.Message, blockHash common.Hash, blockNumber big.Int, txHash common.Hash, index uint64, err error) *ActionTrace {
+	if msg == nil {
+		return createErrorTrace(blockHash, blockNumber, nil, &common.Address{}, txHash, 0, []byte{}, hexutil.Big{}, index, err)
+	}
+	from := msg.From()
+	return createErrorTrace(blockHash, blockNumber, &from, msg.To(), txHash, msg.Gas(), msg.Data(), hexutil.Big(*msg.Value()), index, err)
+}
+
+func createErrorTrace(blockHash common.Hash, blockNumber big.Int,
+	from *common.Address, to *common.Address,
+	txHash common.Hash, gas uint64, input []byte,
+	value hexutil.Big, index uint64, err error) *ActionTrace {
+
+	if from == nil {
+		from = &common.Address{}
+	}
+
+	var blockTrace *ActionTrace
+	var txAction *AddressAction
+	callType := CALL
+	if to != nil {
+		blockTrace = NewActionTrace(blockHash, blockNumber, txHash, index, CALL)
+		txAction = NewAddressAction(from, gas, input, to, hexutil.Big{}, &callType)
+	} else {
+		blockTrace = NewActionTrace(blockHash, blockNumber, txHash, index, CREATE)
+		txAction = NewAddressAction(from, gas, input, nil, hexutil.Big{}, nil)
+	}
+	blockTrace.Action = txAction
+	blockTrace.Result = nil
+	if err != nil {
+		blockTrace.Error = err.Error()
+	} else {
+		blockTrace.Error = "Reverted"
+	}
+	return blockTrace
+}


### PR DESCRIPTION
## Summary
- Backports the replay-based `trace_block`, `trace_transaction`, and `trace_get` API to the `v2.0.0-rc.1` mainnet RPC baseline.
- Registers the public `trace` namespace so Blockscout/VinuExplorer can fetch native internal transfers.
- Adds durable mainnet hotfix/runbook notes under `docs/mainnet-trace-rpc-hotfix-2026-05-17.md`.

## Operational context
- This is an operational hotfix branch for the current mainnet RPC baseline, not the Elemont development line.
- Deployed source tag: `v2.0.0-rc.1-trace.1` at `60e43d6fa0f2a6d181fc6a0ef3fb897c709740df`.
- PR head also contains a docs-only commit after the deployed tag; do not move the tag.
- Mainnet RPC host already running the tagged code: `i-083fffeeb03583a18` (`ip-10-0-142-137`).
- Runtime binary: `/home/ubuntu/VinuChain/build/opera`.
- Rollback binary: `/home/ubuntu/VinuChain/build/opera.pre-trace-20260517T100059Z`.
- Built candidate SHA256: `1ce6cd848046974958cc9ef9b23447f0b95d81d0ed9189d0e758062e5556ecda`.

## Verification
- `go test ./ethapi ./txtrace ./gossip ./cmd/opera -run '^$'`
- `go build -o build/opera-trace ./cmd/opera`
- `git diff --check`
- Live `rpc_modules` includes `trace`.
- Live `trace_block 0xcf1ae9` includes the four child native transfers for `0xdd2007fae2f91fd0db5321a06097706c738ddc79d147e3f6eb4acb8153977b56`.

## Merge note
- Merge into `release/v2.0.0-rc.1` without squash if we want the tagged deployed commit to remain directly reachable.
- If code changes are needed later, build a new binary and create a new tag such as `v2.0.0-rc.1-trace.2`.